### PR TITLE
Add ability to use a secrets.ini file + jinja templating to apply secrets in cli apps

### DIFF
--- a/prosper/common/common_config.cfg
+++ b/prosper/common/common_config.cfg
@@ -15,10 +15,10 @@
 [TEST]
     request_logname = urllib3.connectionpool
     request_POST_endpoint = https://discordapp.com:443 "POST /api/webhooks/{serverid}/{api_key} HTTP/1.1" 204 0
-    request_new_connection = Starting new HTTPS connection (1): discordapp.com
-    slack_new_connection = Starting new HTTPS connection (1): hooks.slack.com
+    request_new_connection = Starting new HTTPS connection (1): discordapp.com:443
+    slack_new_connection = Starting new HTTPS connection (1): hooks.slack.com:443
     slack_POST_endpoint = https://hooks.slack.com:443 "POST {webhook_info} HTTP/1.1" 200 22
-    hipchat_new_connection = Starting new HTTPS connection (1): {hipchat_hostname}
+    hipchat_new_connection = Starting new HTTPS connection (1): {hipchat_hostname}:443
     hipchat_POST_endpoint = {hipchat_hostname}{hipchat_port} "POST {webhook_info} HTTP/1.1" 204 0
     hipchat_hostname = #SECRET
     hipchat_port = :443

--- a/prosper/common/prosper_cli.py
+++ b/prosper/common/prosper_cli.py
@@ -47,7 +47,16 @@ class ProsperApplication(cli.Application):
             base_config = cfg_fh.read()
 
         print(base_config)
-        exit()
+        exit(2)
+
+    @cli.switch(
+        ['--secret-cfg'],
+        cli.ExistingFile,
+        help='Secrets .ini file for jinja2 template'
+    )
+    def load_secrets(self, secret_path):
+        """render secrets into config object"""
+        self._config = p_config.render_secrets(self.config_path, secret_path)
 
     _logger = None
     @property

--- a/prosper/common/prosper_config.py
+++ b/prosper/common/prosper_config.py
@@ -288,7 +288,8 @@ def get_local_config_filepath(
         str: Path to local config, or global if path DNE
 
     """
-    local_config_filepath = config_filepath.replace('.cfg', '_local.cfg')
+    local_config_name = path.basename(config_filepath).split('.')[0] + '_local.cfg'
+    local_config_filepath = path.join(path.split(config_filepath)[0], local_config_name)
 
     real_config_filepath = ''
     if path.isfile(local_config_filepath) or force_local:

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ def get_version(package_name):
     """find __version__ for making package
 
     Args:
-        package_path (str): path to _version.py folder (abspath > relpath)
+        package_name (str): path to _version.py folder (abspath > relpath)
 
     Returns:
-        (str) __version__ value
+        str: __version__ value
 
     """
     module = 'prosper.' + package_name + '._version'
@@ -139,6 +139,8 @@ setup(
         ],
     },
     install_requires=[
+        'anyconfig',
+        'anytemplate',
         'requests',
         'semantic_version',
         'plumbum',

--- a/setup.py
+++ b/setup.py
@@ -141,9 +141,10 @@ setup(
     install_requires=[
         'anyconfig',
         'anytemplate',
+        'jinja2',
+        'plumbum',
         'requests',
         'semantic_version',
-        'plumbum',
     ],
     tests_require=[
         'pytest>=3.3.0',

--- a/tests/test_config.cfg.j2
+++ b/tests/test_config.cfg.j2
@@ -1,0 +1,6 @@
+[TEST]
+    secret = {{test.secret}}
+    key1 = vals
+    key2 = 100
+    key3 =
+    nokey =

--- a/tests/test_prosper_cli.py
+++ b/tests/test_prosper_cli.py
@@ -169,7 +169,7 @@ class TestCLI:
 
     def test_dump_config(self):
         """validate --dump-config works as expected"""
-        result = self.cli('--dump-config')
+        retcode, result, stderr = self.cli.run(['--dump-config'], retcode=2)
 
         config = configparser.ConfigParser()
         config.read_string(result)

--- a/tests/test_prosper_config.py
+++ b/tests/test_prosper_config.py
@@ -29,6 +29,18 @@ def test_setup_environment():
     expected_val = prosper_config.get_value_from_environment('TEST', 'dummy_val')
     assert expected_val == ENV_TEST_1
 
+def test_render_secrets():
+    """happypath test for p_config.render_secrets"""
+    config_path = path.join(HERE, 'test_config.cfg.j2')
+    secret_path = path.join(HERE, 'test_secret.ini')
+
+    config = prosper_config.render_secrets(config_path, secret_path)
+
+    assert isinstance(config, prosper_config.ProsperConfig)
+    assert config.get_option('TEST', 'secret') == 'butts'
+    os.environ['PROSPER_LOCAL__hello'] = 'world'
+    assert config.get_option('LOCAL', 'hello') == 'world'
+
 TEST_BAD_CONFIG_PATH = path.join(HERE, 'bad_config.cfg')
 TEST_BAD_PATH = path.join(HERE, 'no_file_here.cfg')
 def test_bad_config():

--- a/tests/test_secret.ini
+++ b/tests/test_secret.ini
@@ -1,0 +1,2 @@
+[test]
+    secret = butts


### PR DESCRIPTION
- Adds `render_secrets()` to `prosper_config` module
    - uses jinja2 templating to obscure secrets
- Adds `--secret-cfg` switch to CLI template
- Updates `get_local_config_filepath()` to use `os.path` utilities rather than just string `replace()`
- Updates tests for python3.6 (python3.5 might not work any more)

sample `credentials.ini` file:
```ini
[logging]
    discord_webhook = https://discordapp.com/api/webhooks/99999/fake-fake_fake-fake
    slack_webhook = https://hooks.slack.com/services/T1FAKE/B1FAKE/fakefake
```